### PR TITLE
fixes root script to use mac adb when on Darwin

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ `uname -s` == "Darwin" ]; then
-	adb=bin/adb-linux
+	adb=bin/adb-mac
         fastboot=bin/fastboot-mac
 elif [ `uname -s` == "Linux" ]; then
 	adb=bin/adb-linux


### PR DESCRIPTION
The root script was mistakenly using bin/adb-linux even when running from a mac.
